### PR TITLE
fix: changes request payload to be sent as json to core's query endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 DB_URL=
+SECRET=
+
+CORE_API_BASE_URL=http://0.0.0.0:5000/api/v1

--- a/utils/core.py
+++ b/utils/core.py
@@ -1,6 +1,7 @@
+import os
 import requests
 
-BASE_URL = 'http://<core-url>/api/v1'    #TODO: Change this to the core URL
+BASE_URL = os.getenv("CORE_API_BASE_URL")
 
 
 def create_knowledge_base(assistant_id):
@@ -12,5 +13,5 @@ def create_knowledge_base(assistant_id):
 
 def send_core_chat(assistant_id, payload):
     url = f'{BASE_URL}/llm/{assistant_id}/query'
-    response = requests.post(url, payload)
+    response = requests.post(url, None, payload)
     return response


### PR DESCRIPTION
**Issue:** The core's endpoint was receiving an empty request's body.
With this change, the payload is now properly sent to the core's endpoint.

Also, setting core's api url as enviroment variable so it's easier to change this configuration.